### PR TITLE
fixed css syntax, hover now works properly

### DIFF
--- a/src/components/MemberCard/style.css
+++ b/src/components/MemberCard/style.css
@@ -9,7 +9,7 @@
 }
 
 .memberCard:hover {
-    scale(1.1);
+    transform: scale(1.1);
 }
 
 .memberCard-header {


### PR DESCRIPTION
Fixed the CSS syntax for the hover effect, it is now working properly.